### PR TITLE
explicitly require rack/oauth2

### DIFF
--- a/lib/ricohapi/mstorage.rb
+++ b/lib/ricohapi/mstorage.rb
@@ -1,6 +1,7 @@
 # Copyright (c) 2016 Ricoh Company, Ltd. All Rights Reserved.
 # See LICENSE for more information
 
+require 'rack/oauth2'
 require 'ricohapi/oauth'
 require 'ricohapi/mstorage/version'
 


### PR DESCRIPTION
CLI作成中に見つけたbugです。
sample appではrack-oauth2が別経路でrequireされていたので見落としてました。

こちらmerge後、v1.0.1をリリース願いたいです。
